### PR TITLE
Update README.md to reflect newer versions of qutebrowser

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ For example:
 
 Symlink `instapaper` bin installed above to `<QUTEBROWSER_DATA_FOLDER>/userscripts/`. You can find out the location to your qutebrowser data folder by checking :version. If the `userscripts` folder doesn't exist, you must create it.
 
-    $ ln -sf ~/.bin/instapaper <QUTEBROWSER_DATA_FOLDER>/instapaper
+    $ ln -sf <INSTALL_PATH>/instapaper <QUTEBROWSER_DATA_FOLDER>/instapaper
+
+You can find out the `<INSTALL_PATH>` by executing `which instapaper` in the command line.
 
 Test it out by running:
 

--- a/README.md
+++ b/README.md
@@ -39,22 +39,16 @@ For example:
 
 ### Qutebrowser userscript
 
-Symlink `instapaper` bin installed above to `~/.local/share/qutebrowser/userscripts/` and make executable:
+Symlink `instapaper` bin installed above to `<QUTEBROWSER_DATA_FOLDER>/userscripts/`. You can find out the location to your qutebrowser data folder by checking :version. If the `userscripts` folder doesn't exist, you must create it.
 
-    $ ln -sf ~/.bin/instapaper ~/.local/share/qutebrowser/userscripts/instapaper
+    $ ln -sf ~/.bin/instapaper <QUTEBROWSER_DATA_FOLDER>/instapaper
 
 Test it out by running:
 
-    :spawn --userscript instapaper qute-add
+    :spawn --userscript instapaper {url}
 
-Add a keyboard shortcut by opening `~/.config/qutebrowser/keys.conf`
-
-    vim +437 ~/.config/qutebrowser/keys.conf
-
-and copying this into the [normal] section (line 47-437).
-
-    spawn -u instapaper qute-add
-        sI
+Add a keyboard shortcut:
+    bind sI spawn --userscript instapaper {url}
 
 Now open Qutebrowser and test out the keyboard shortcut. You can change `sI` so whatever keyboard shortcut you like.
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ You can find out the `<INSTALL_PATH>` by executing `which instapaper` in the com
 Creating global environment variables might be somewhat painful in some operating systems (e.g. OS X). Alternatively, you can use a wrapper script to export the environment variables to the instapaper script's execution context. This wrapper has been included to this repo: [instaqute](instaqute).
 
 If you choose to use it, follow the instructions above replacing `instapaper` with `instaqute` (make sure you edit the instaqute script, add your credentials and the path to the instapaper script):
+
     $ ln -sf <INSTALL_PATH>/instaqute <QUTEBROWSER_DATA_FOLDER>/instaqute
 
 #### Testing

--- a/README.md
+++ b/README.md
@@ -45,12 +45,21 @@ Symlink `instapaper` bin installed above to `<QUTEBROWSER_DATA_FOLDER>/userscrip
 
 You can find out the `<INSTALL_PATH>` by executing `which instapaper` in the command line.
 
+#### Alternative userscript setup
+
+Creating global environment variables might be somewhat painful in some operating systems (e.g. OS X). Alternatively, you can use a wrapper script to export the environment variables to the instapaper script's execution context. This wrapper has been included to this repo: [instaqute](instaqute).
+
+If you choose to use it, follow the instructions above replacing `instapaper` with `instaqute` (make sure you edit the instaqute script, add your credentials and the path to the instapaper script):
+    $ ln -sf <INSTALL_PATH>/instaqute <QUTEBROWSER_DATA_FOLDER>/instaqute
+
+#### Testing
+
 Test it out by running:
 
-    :spawn --userscript instapaper {url}
+    :spawn --userscript (instapaper/instaqute) {url}
 
 Add a keyboard shortcut:
-    bind sI spawn --userscript instapaper {url}
+    bind sI spawn --userscript (instapaper/instaqute) {url}
 
 Now open Qutebrowser and test out the keyboard shortcut. You can change `sI` so whatever keyboard shortcut you like.
 

--- a/install
+++ b/install
@@ -44,7 +44,7 @@ echo "instapaper> Done. Linked bin from $DEST to:
 
 ## Prompt user to export pw -------------------------------------------
 
-echo "instapaper> Note: you must export your Instagram username and password in your shell:
+echo "instapaper> Note: you must export your Instapaper username and password in your shell:
 
     export INSTAPAPER_USER=<username>
     export INSTAPAPER_PASS=<password>

--- a/instaqute
+++ b/instaqute
@@ -1,0 +1,5 @@
+#!/bin/bash
+export INSTAPAPER_USER=<YOUR_USERNAME>
+export INSTAPAPER_PASS=<YOUR_PASSWORD>
+<BIN_FOLDER>/instapaper add $1 # You can find out the path to this file by running "which instapaper" in the command line
+exit 0


### PR DESCRIPTION
The instructions weren't taking into consideration the fact that different OSes have different paths to qutebrowser's data folder. Also updated the instructions to reflect newer qutebrowser versions (keys.conf file has been phased out).